### PR TITLE
fix. 스터디룸 조회 시 로그인을 해야만 조회되는 로직 수정

### DIFF
--- a/src/main/java/com/jungle/studybbitback/domain/room/controller/RoomController.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/controller/RoomController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/room")
@@ -50,10 +51,26 @@ public class RoomController {
         return ResponseEntity.ok(response);
     }
 
+    // 화상회의 시작
+    @PostMapping("/{roomId}/start-meeting")
+    public ResponseEntity<String> startMeeting(@PathVariable("roomId") Long roomId) {
+        UUID meetingId = roomService.startMeeting(roomId);
+        return ResponseEntity.ok(meetingId.toString()); // 생성된 meetingId를 반환
+    }
+
+    // 화상회의 종료
+    @PostMapping("/{roomId}/end-meeting")
+    public ResponseEntity<String> endMeeting(@PathVariable("roomId") Long roomId) {
+        roomService.endMeeting(roomId);
+        return ResponseEntity.ok("화상회의가 종료되었습니다.");
+    }
+
     // 방에 참여하기 (사용자가 스스로 방에 들어감)
     @PostMapping("/{roomId}/join")
     public ResponseEntity<JoinRoomResponseDto> joinRoom(@PathVariable("roomId") Long roomId, @RequestBody JoinRoomRequestDto requestDto) {
         JoinRoomResponseDto response = roomService.joinRoom(roomId, requestDto);
         return ResponseEntity.ok(response);
     }
+
+
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/room/GetRoomDashboardResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/room/GetRoomDashboardResponseDto.java
@@ -1,0 +1,23 @@
+package com.jungle.studybbitback.domain.room.dto.room;
+
+import com.jungle.studybbitback.domain.room.entity.Room;
+
+public class GetRoomDashboardDto {
+    private Long id;
+    private String name;
+    private String detail;
+    private Integer participants;
+    private Integer maxParticipants;
+    private Boolean isMeetingActive;
+    private Long leaderId;
+
+    public GetRoomDashboardDto(Room room) {
+        this.id = room.getId();
+        this.name = room.getName();
+        this.detail = room.getDetail();
+        this.participants = room.getParticipants();
+        this.maxParticipants = room.getMaxParticipants();
+        this.isMeetingActive = room.getMeetingId() != null;
+        this.leaderId = room.getLeaderId();
+    }
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/room/GetRoomDetailResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/room/GetRoomDetailResponseDto.java
@@ -1,0 +1,24 @@
+package com.jungle.studybbitback.domain.room.dto.room;
+
+import com.jungle.studybbitback.domain.room.entity.Room;
+import lombok.Getter;
+
+@Getter
+public class GetRoomDetailDto {
+    private Long id;
+    private String name;
+    private String detail;
+    private Integer participants;
+    private Integer maxParticipants;
+    private String profileImageUrl;
+
+    public GetRoomDetailDto(Room room) {
+        this.id = room.getId();
+        this.name = room.getName();
+        this.detail = room.getDetail();
+        this.participants = room.getParticipants();
+        this.maxParticipants = room.getMaxParticipants();
+        this.profileImageUrl = room.getProfileImageUrl();
+    }
+
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/room/GetRoomResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/room/GetRoomResponseDto.java
@@ -17,6 +17,7 @@ public class GetRoomResponseDto {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private Long leaderId;
+    private boolean isMeetingAcitve;
 
     public GetRoomResponseDto(Room room) {
         this.id = room.getId();
@@ -29,5 +30,6 @@ public class GetRoomResponseDto {
         this.createdAt = room.getCreatedAt();
         this.modifiedAt = room.getModifiedAt();
         this.leaderId = room.getLeaderId();
+        this.isMeetingAcitve = room.getMeetingId() != null;
     }
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/entity/Room.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/entity/Room.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -41,6 +42,9 @@ public class Room extends ModifiedTimeEntity {
     @Column(nullable = false, name = "leader_id") //leaderId로 쓸 ID임
     private Long leaderId;
 
+    @Column(name = "meeting_id", columnDefinition = "UUID", unique = true)
+    private UUID meetingId; // 화상회의 고유 ID
+
     @OneToMany (mappedBy = "room")
     private Set<RoomBoard> roomBoard = new HashSet<>();
 
@@ -55,10 +59,34 @@ public class Room extends ModifiedTimeEntity {
         this.leaderId = memberId;
     }
 
+    // 테스트 전용 생성자 (ID 설정)
+    public Room(Long id, CreateRoomRequestDto requestDto, Long leaderId) {
+        this.id = id;  // 테스트 시 ID 설정
+        this.name = requestDto.getName();
+        this.roomUrl = requestDto.getRoomUrl();
+        this.password = requestDto.getPassword();
+        this.detail = requestDto.getDetail();
+        this.participants = 1;
+        this.maxParticipants = requestDto.getMaxParticipants();
+        this.profileImageUrl = requestDto.getProfileImageUrl();
+        this.leaderId = leaderId;
+    }
+
+
     public void updateDetails(UpdateRoomRequestDto requestDto) {
         this.password = requestDto.getPassword();
         this.detail = requestDto.getDetail();
         this.profileImageUrl = requestDto.getProfileImageUrl();
     }
+
+    public void startMeeting() {
+        this.meetingId = UUID.randomUUID(); // 새로운 meetingId 생성
+    }
+
+    public void endMeeting() {
+        this.meetingId = null; // meetingId 제거하여 회의 종료 상태로 설정
+    }
+
+
 
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/service/RoomService.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/service/RoomService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -104,6 +105,23 @@ public class RoomService {
 
         roomRepository.delete(room);
         return "스터디룸이 삭제되었습니다.";
+    }
+
+    @Transactional
+    public UUID startMeeting(Long roomId) {
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("Room not found"));
+
+        room.startMeeting(); // 매번 새로운 meetingId 생성
+        return room.getMeetingId();
+    }
+
+    @Transactional
+    public void endMeeting(Long roomId) {
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("Room not found"));
+
+        room.endMeeting();
     }
 
     @Transactional

--- a/src/test/java/com/jungle/studybbitback/domain/room/service/RoomMemberServiceTest.java
+++ b/src/test/java/com/jungle/studybbitback/domain/room/service/RoomMemberServiceTest.java
@@ -1,0 +1,4 @@
+package com.jungle.studybbitback.domain.room.service;
+
+public class RoomMemberServiceTest {
+}

--- a/src/test/java/com/jungle/studybbitback/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/com/jungle/studybbitback/domain/room/service/RoomServiceTest.java
@@ -6,6 +6,8 @@ import com.jungle.studybbitback.domain.room.dto.room.CreateRoomRequestDto;
 import com.jungle.studybbitback.domain.room.dto.room.CreateRoomResponseDto;
 import com.jungle.studybbitback.domain.room.entity.Room;
 import com.jungle.studybbitback.domain.room.respository.RoomRepository;
+import com.jungle.studybbitback.domain.room.respository.RoomMemberRepository;
+import com.jungle.studybbitback.domain.member.repository.MemberRepository;
 import com.jungle.studybbitback.jwt.dto.CustomUserDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,11 +21,13 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
 
 class RoomServiceTest {
 
@@ -31,6 +35,12 @@ class RoomServiceTest {
 
     @Mock
     private RoomRepository roomRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RoomMemberRepository roomMemberRepository;
 
     @InjectMocks
     private RoomService roomService;
@@ -40,23 +50,28 @@ class RoomServiceTest {
         MockitoAnnotations.openMocks(this);
 
         // Mock된 Member 객체 생성
-        Member mockMember = new Member(1L,"testUser@example.com", "password", "testUser", MemberRoleEnum.ROLE_USER);
-
+        Member mockMember = new Member(1L, "testUser@example.com", "password", "testUser", MemberRoleEnum.ROLE_USER);
         logger.info("Member ID: {}", mockMember.getId());
 
         // Mock된 사용자 인증 설정
         CustomUserDetails userDetails = new CustomUserDetails(mockMember);
-        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userDetails, null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
-
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                userDetails, null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
         SecurityContextHolder.getContext().setAuthentication(auth);
 
         // SecurityContextHolder의 인증 정보 확인
         logger.info("Authenticated User ID from SecurityContextHolder: {}", userDetails.getMemberId());
+
+        // ** memberRepository의 findById에 대한 Mock 설정 **
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
+
+        // ** roomMemberRepository의 save에 대한 Mock 설정 **
+        when(roomMemberRepository.save(any())).thenReturn(null);
     }
 
     @Test
     void createRoom_shouldReturnRoomResponseDto() {
-        // Given: CreateRoomRequestDto 객체 생성
+        // Given
         CreateRoomRequestDto requestDto = CreateRoomRequestDto.builder()
                 .name("Room1")
                 .roomUrl("url1")
@@ -68,18 +83,54 @@ class RoomServiceTest {
 
         logger.info("Testing createRoom with request DTO: {}", requestDto);
 
-        // Mock 설정된 Room 객체
-        Room room = new Room(requestDto, 1L); // 예시용 Room 객체 생성
-        when(roomRepository.saveAndFlush(any(Room.class))).thenReturn(room);  //!! saveAndFlush에 대한 Mock 추가
+        // Mock Room 객체 설정
+        Room room = new Room(1L, requestDto, 1L); // 새로운 생성자를 사용해 ID 설정
+        when(roomRepository.saveAndFlush(any(Room.class))).thenReturn(room);
         logger.info("Mocked roomRepository to return Room: {}", room);
 
-        // When: roomService.createRoom 호출
+        // When
         CreateRoomResponseDto response = roomService.createRoom(requestDto);
 
-        // Then: response 필드값 확인
+        // Then
         logger.info("Received response from createRoom: {}", response);
+        assertNotNull(response);
         assertEquals("Room1", response.getName());
         assertEquals("url1", response.getRoomUrl());
-        assertNotNull(response); // Null이 아닌지 확인
+        assertNull(room.getMeetingId()); // 초기 생성 시 meetingId는 null
+    }
+
+    @Test
+    void startMeeting_shouldGenerateNewMeetingId() {
+        // Given
+        CreateRoomRequestDto requestDto = CreateRoomRequestDto.builder().build();
+        Room room = new Room(1L, requestDto, 1L); // 새로운 생성자를 사용해 ID 설정
+
+        // ** roomRepository의 findById에 대한 Mock 설정 **
+        when(roomRepository.findById(anyLong())).thenReturn(Optional.of(room));
+
+        // When
+        UUID meetingId = roomService.startMeeting(room.getId());
+
+        // Then
+        assertNotNull(meetingId); // 새로운 meetingId가 생성됨
+        assertEquals(meetingId, room.getMeetingId()); // room의 meetingId가 생성된 ID와 같아야 함
+        logger.info("Generated meetingId: {}", meetingId);
+    }
+    @Test
+    void endMeeting_shouldSetMeetingIdToNull() {
+        // Given
+        CreateRoomRequestDto requestDto = CreateRoomRequestDto.builder().build();
+        Room room = new Room(1L, requestDto, 1L); // 새로운 생성자를 사용해 ID 설정
+        room.startMeeting(); // meetingId가 이미 생성된 상태
+
+        // ** roomRepository의 findById에 대한 Mock 설정 **
+        when(roomRepository.findById(anyLong())).thenReturn(Optional.of(room));
+
+        // When
+        roomService.endMeeting(room.getId());
+
+        // Then
+        assertNull(room.getMeetingId()); // meetingId가 null로 설정되어야 함
+        logger.info("Meeting ended, meetingId is now: {}", room.getMeetingId());
     }
 }


### PR DESCRIPTION
GetRoomResponseDto 분리
- GetRoom : 비회원도 볼 수 있는 메인 스터디 목록 조회
- GetRoomDetail : 비회원도 볼 수 있는 스터디 정보 모달창 조회
- GetRoomDashboard : 스터디원으로 스터디그룹 입장 시 보이는 대시보드 홈 조회

Room Entity에 meetingId(화상회의아이디)를 추가했습니다.
방을 생성 시 바로 생기지 않고, 화상회의 시작을 눌러야 meetingId가 생성됩니다.
화상 회의 종료 시 meetingId도 삭제됩니다.
GetRoomDashboard 에서 이 화상회의의 activation 상태를 조회 가능합니다.
추후에 대시보드에 공지사항이랑 일정 표도 보여야 하는데 추후 엔터티 수정이 일어날 것 같네요.

기다려주셔서 감사합니다.

🔨미구현
스터디그룹 가입(join) 및 나가기(leave), 스터디멤버 초대(invite) 기능은 화상회의를 시작하는 동작이 없어서, 화상회의 id가 null로 받아져, 에러가 나는 상황이므로 테스트 때 추가로 설정해야 합니다. 아직 진행은 하지 않았습니다.
현재 Room 엔터티에 추가되어있는 테스트용 코드는 나중에 함께 지우도록 하겠습니다.

제가 오해하고 있는 부분은 코멘트 남겨주십쇼.