### PR TITLE
[Room] 스터디룸 게시글 CRUD, 댓글 CUD, 내 스터디 조회

### DIFF
--- a/src/main/java/com/jungle/studybbitback/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jungle/studybbitback/domain/member/controller/MemberController.java
@@ -1,12 +1,15 @@
 package com.jungle.studybbitback.domain.member.controller;
 
+import com.jungle.studybbitback.domain.member.dto.GetMyRoomResponseDto;
 import com.jungle.studybbitback.domain.member.dto.SignupRequestDto;
 import com.jungle.studybbitback.domain.member.dto.UpdateMemberRequestDto;
 import com.jungle.studybbitback.domain.member.dto.UpdateMemberResponseDto;
 import com.jungle.studybbitback.domain.member.service.MemberService;
+import com.jungle.studybbitback.domain.room.entity.Room;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,6 +41,16 @@ public class MemberController {
             @PathVariable("memberId") Long memberId,
             @ModelAttribute UpdateMemberRequestDto requestDto) {
         UpdateMemberResponseDto responseDto = memberService.updateMember(memberId, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 내 스터디 조회
+    @GetMapping("/room/{memberId}")
+    public ResponseEntity<GetMyRoomResponseDto> getUserStudyRooms(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "4") int size) {
+        GetMyRoomResponseDto responseDto = memberService.getUserStudyRooms(memberId, page, size);
         return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/jungle/studybbitback/domain/member/dto/GetMyRoomResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/member/dto/GetMyRoomResponseDto.java
@@ -1,0 +1,26 @@
+package com.jungle.studybbitback.domain.member.dto;
+
+import com.jungle.studybbitback.domain.room.dto.room.GetRoomResponseDto;
+import com.jungle.studybbitback.domain.room.entity.Room;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class GetMyRoomResponseDto {
+
+    private List<GetRoomResponseDto> myRooms;
+    private int totalPages;
+    private long totalElements;
+
+    public GetMyRoomResponseDto(Page<Room> roomPage) {
+        this.myRooms = roomPage.stream()
+                .map(GetRoomResponseDto::new)
+                .collect(Collectors.toList());
+        this.totalPages = roomPage.getTotalPages();
+        this.totalElements = roomPage.getTotalElements();
+
+    }
+}

--- a/src/main/java/com/jungle/studybbitback/domain/member/entity/Member.java
+++ b/src/main/java/com/jungle/studybbitback/domain/member/entity/Member.java
@@ -2,10 +2,14 @@ package com.jungle.studybbitback.domain.member.entity;
 
 import com.jungle.studybbitback.common.entity.ModifiedTimeEntity;
 import com.jungle.studybbitback.domain.member.dto.UpdateMemberRequestDto;
+import com.jungle.studybbitback.domain.room.entity.RoomMember;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
@@ -32,6 +36,10 @@ public class Member extends ModifiedTimeEntity {
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private MemberRoleEnum role;
+
+    // Member와 연결된 RoomMember를 통해 참여한 Room들을 조회
+    @OneToMany(mappedBy = "member")
+    private Set<RoomMember> roomMembers = new HashSet<>();
 
     public Member(String email, String password, String nickname, MemberRoleEnum role) {
         this.email = email;

--- a/src/main/java/com/jungle/studybbitback/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/jungle/studybbitback/domain/member/repository/MemberRepository.java
@@ -1,6 +1,9 @@
 package com.jungle.studybbitback.domain.member.repository;
 
 import com.jungle.studybbitback.domain.member.entity.Member;
+import com.jungle.studybbitback.domain.room.entity.Room;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/jungle/studybbitback/domain/member/service/MemberService.java
+++ b/src/main/java/com/jungle/studybbitback/domain/member/service/MemberService.java
@@ -1,16 +1,24 @@
 package com.jungle.studybbitback.domain.member.service;
 
 import com.jungle.studybbitback.common.file.service.FileService;
+import com.jungle.studybbitback.domain.member.dto.GetMyRoomResponseDto;
 import com.jungle.studybbitback.domain.member.dto.SignupRequestDto;
 import com.jungle.studybbitback.domain.member.dto.UpdateMemberRequestDto;
 import com.jungle.studybbitback.domain.member.dto.UpdateMemberResponseDto;
 import com.jungle.studybbitback.domain.member.entity.Member;
 import com.jungle.studybbitback.domain.member.entity.MemberRoleEnum;
 import com.jungle.studybbitback.domain.member.repository.MemberRepository;
+import com.jungle.studybbitback.domain.room.entity.Room;
+import com.jungle.studybbitback.domain.room.entity.RoomMember;
+import com.jungle.studybbitback.domain.room.respository.RoomMemberRepository;
+import com.jungle.studybbitback.domain.room.respository.RoomRepository;
 import com.jungle.studybbitback.jwt.JWTUtil;
 import com.jungle.studybbitback.jwt.dto.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -25,6 +33,8 @@ public class MemberService {
     private final JWTUtil jwtUtil;
 
     private final MemberRepository memberRepository;
+    private final RoomRepository roomRepository;
+    private final RoomMemberRepository roomMemberRepository;
     private final FileService fileService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private static final String ADMIN_TOKEN = "AAABnvxRVklrnYxKZ0aHgTBcXukeZygoC";
@@ -85,4 +95,17 @@ public class MemberService {
 
         return new UpdateMemberResponseDto(member);
     }
+
+    @Transactional
+    public GetMyRoomResponseDto getUserStudyRooms(Long memberId, int page, int size){
+        Pageable pageable = PageRequest.of(page, size);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        // RoomRepository에서 수정된 메서드를 사용하여 Member가 속한 Room을 페이지로 조회
+        Page<Room> roomPage = roomRepository.findByRoomMembersMember(member, pageable);
+
+        return new GetMyRoomResponseDto(roomPage);
+    }
+
 }

--- a/src/main/java/com/jungle/studybbitback/domain/member/service/MemberService.java
+++ b/src/main/java/com/jungle/studybbitback/domain/member/service/MemberService.java
@@ -98,6 +98,14 @@ public class MemberService {
 
     @Transactional
     public GetMyRoomResponseDto getUserStudyRooms(Long memberId, int page, int size){
+
+        CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Long loggedInMemberId = userDetails.getMemberId();  // 로그인한 사용자의 ID
+
+        if (!loggedInMemberId.equals(memberId)) {
+            throw new IllegalArgumentException("본인만 조회할 수 있습니다.");
+        }
+
         Pageable pageable = PageRequest.of(page, size);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(()-> new IllegalArgumentException("사용자가 존재하지 않습니다."));

--- a/src/main/java/com/jungle/studybbitback/domain/room/controller/roomboard/RoomBoardCommentController.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/controller/roomboard/RoomBoardCommentController.java
@@ -1,4 +1,54 @@
-//package com.jungle.studybbitback.domain.room.controller.roomboard;
-//
-//public class RoomBoardCommentController {
-//}
+package com.jungle.studybbitback.domain.room.controller.roomboard;
+
+import com.jungle.studybbitback.domain.room.dto.roomboardcomment.CreateRoomBoardCommentRequestDto;
+import com.jungle.studybbitback.domain.room.dto.roomboardcomment.CreateRoomBoardCommentResponseDto;
+import com.jungle.studybbitback.domain.room.dto.roomboardcomment.UpdateRoomBoardCommentRequestDto;
+import com.jungle.studybbitback.domain.room.dto.roomboardcomment.UpdateRoomBoardCommentResponseDto;
+import com.jungle.studybbitback.domain.room.service.roomboard.RoomBoardCommentService;
+
+import com.jungle.studybbitback.jwt.dto.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/room-board-comment")
+@RequiredArgsConstructor
+public class RoomBoardCommentController {
+
+    private final RoomBoardCommentService commentService;
+
+    // 댓글 추가
+    @PostMapping
+    public ResponseEntity<CreateRoomBoardCommentResponseDto> createComment(
+            @RequestBody CreateRoomBoardCommentRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMemberId();
+        CreateRoomBoardCommentResponseDto responseDto = commentService.createComment(requestDto, memberId);
+        return ResponseEntity.status(201).body(responseDto);
+    }
+
+    // 댓글 수정
+    @PostMapping("/{roomBoardCommentId}")
+    public ResponseEntity<UpdateRoomBoardCommentResponseDto> updateComment(
+            @PathVariable Long roomBoardCommentId,
+            @RequestBody UpdateRoomBoardCommentRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMemberId();
+        UpdateRoomBoardCommentResponseDto updatedComment = commentService.updateComment(roomBoardCommentId, requestDto, memberId);
+        return ResponseEntity.ok(updatedComment);
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/{roomBoardCommentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long roomBoardCommentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMemberId();
+        commentService.deleteComment(roomBoardCommentId, memberId);
+        return ResponseEntity.noContent().build();
+    }
+
+
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/controller/roomboard/RoomBoardController.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/controller/roomboard/RoomBoardController.java
@@ -43,8 +43,15 @@ public class RoomBoardController {
 
     // 스터디룸 게시글 상세 조회
     @GetMapping("/detail/{roomBoardId}")
-    public ResponseEntity<GetRoomBoardDetailResponseDto> getRoomBoardDetail(@PathVariable Long roomBoardId) {
-        GetRoomBoardDetailResponseDto responseDto = roomBoardService.getRoomBoardDetail(roomBoardId);
+    public ResponseEntity<GetRoomBoardDetailResponseDto> getRoomBoardDetail(
+            @PathVariable Long roomBoardId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
+    ) { //게시글 댓글 함께 조회
+        GetRoomBoardDetailResponseDto responseDto = roomBoardService.getRoomBoardDetail(roomBoardId, page, size);
         return ResponseEntity.ok(responseDto);
     }
+
+    // 스터디룸 게시글 수정
+
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/controller/roomboard/RoomBoardController.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/controller/roomboard/RoomBoardController.java
@@ -1,9 +1,6 @@
 package com.jungle.studybbitback.domain.room.controller.roomboard;
 
-import com.jungle.studybbitback.domain.room.dto.roomboard.CreateRoomBoardRequestDto;
-import com.jungle.studybbitback.domain.room.dto.roomboard.CreateRoomBoardResponseDto;
-import com.jungle.studybbitback.domain.room.dto.roomboard.GetRoomBoardDetailResponseDto;
-import com.jungle.studybbitback.domain.room.dto.roomboard.GetRoomBoardResponseDto;
+import com.jungle.studybbitback.domain.room.dto.roomboard.*;
 import com.jungle.studybbitback.domain.room.service.roomboard.RoomBoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -53,5 +50,20 @@ public class RoomBoardController {
     }
 
     // 스터디룸 게시글 수정
+// 게시글 수정
+    @PostMapping("/{roomBoardId}")
+    public ResponseEntity<UpdateRoomBoardResponseDto> updateRoomBoard(
+            @PathVariable Long roomBoardId,
+            @RequestBody UpdateRoomBoardRequestDto requestDto) {
+        UpdateRoomBoardResponseDto responseDto = roomBoardService.updateRoomBoard(roomBoardId, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 게시글 삭제
+    @DeleteMapping("/{roomBoardId}")
+    public ResponseEntity<Void> deleteRoomBoard(@PathVariable Long roomBoardId) {
+        roomBoardService.deleteRoomBoard(roomBoardId);
+        return ResponseEntity.noContent().build();
+    }
 
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/GetRoomBoardDetailResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/GetRoomBoardDetailResponseDto.java
@@ -1,13 +1,21 @@
 package com.jungle.studybbitback.domain.room.dto.roomboard;
 
+import com.jungle.studybbitback.domain.member.entity.Member;
 import com.jungle.studybbitback.domain.member.repository.MemberRepository;
+import com.jungle.studybbitback.domain.room.dto.roomboardcomment.GetRoomBoardCommentResponseDto;
 import com.jungle.studybbitback.domain.room.entity.roomboard.RoomBoard;
+import com.jungle.studybbitback.domain.room.entity.roomboard.RoomBoardComment;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class GetRoomBoardDetailResponseDto {
     private Long roomBoardId;
@@ -16,16 +24,31 @@ public class GetRoomBoardDetailResponseDto {
     private String createdBy; // 게시글 작성자 (닉네임)
     private Long roomId;
     private LocalDateTime createdAt;
+    private Page<GetRoomBoardCommentResponseDto> comments; // 게시글에 대한 댓글 리스트
 
-    // RoomBoard 엔티티를 DTO로 변환 (닉네임을 외부에서 입력받음)
-    public static GetRoomBoardDetailResponseDto from(RoomBoard roomBoard, String createdByNickname) {
+    public static GetRoomBoardDetailResponseDto from(RoomBoard roomBoard, String createdByNickname, Page<RoomBoardComment> comments, MemberRepository memberRepository) {
+        Page<GetRoomBoardCommentResponseDto> commentDtos = comments.map(comment -> {
+            String commentCreatedByNickname = memberRepository.findById(comment.getCreatedBy())
+                    .map(Member::getNickname)
+                    .orElse("알 수 없음");
+            return new GetRoomBoardCommentResponseDto(
+                    comment.getId(),
+                    comment.getContent(),
+                    commentCreatedByNickname,
+                    comment.getCreatedAt(),
+                    roomBoard.getId()
+            );
+        });
+
+        // 모든 필드를 초기화하는 생성자 사용
         return new GetRoomBoardDetailResponseDto(
                 roomBoard.getId(),
                 roomBoard.getTitle(),
                 roomBoard.getContent(),
-                createdByNickname, // 닉네임을 외부에서 전달
+                createdByNickname,
                 roomBoard.getRoom().getId(),
-                roomBoard.getCreatedAt()
+                roomBoard.getCreatedAt(),
+                commentDtos
         );
     }
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/GetRoomBoardResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/GetRoomBoardResponseDto.java
@@ -3,10 +3,12 @@ package com.jungle.studybbitback.domain.room.dto.roomboard;
 import com.jungle.studybbitback.domain.room.entity.roomboard.RoomBoard;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class GetRoomBoardResponseDto {
     private Long roomBoardId;

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/UpdateRoomBoardRequestDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/UpdateRoomBoardRequestDto.java
@@ -1,4 +1,16 @@
 package com.jungle.studybbitback.domain.room.dto.roomboard;
 
+import lombok.Getter;
+
+@Getter
 public class UpdateRoomBoardRequestDto {
+    private String title;
+    private String content;
+
+
+    // 모든 필드를 초기화하는 생성자
+    public UpdateRoomBoardRequestDto(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/UpdateRoomBoardResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/UpdateRoomBoardResponseDto.java
@@ -1,4 +1,16 @@
 package com.jungle.studybbitback.domain.room.dto.roomboard;
 
+import lombok.Getter;
+
+@Getter
 public class UpdateRoomBoardResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+
+    public UpdateRoomBoardResponseDto(Long id, String title, String content) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/CreateRoomBoardCommentRequestDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/CreateRoomBoardCommentRequestDto.java
@@ -1,0 +1,11 @@
+package com.jungle.studybbitback.domain.room.dto.roomboardcomment;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateRoomBoardCommentRequestDto {
+    private Long roomBoardId;
+    private String content;
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/CreateRoomBoardCommentResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/CreateRoomBoardCommentResponseDto.java
@@ -1,0 +1,38 @@
+package com.jungle.studybbitback.domain.room.dto.roomboardcomment;
+
+import com.jungle.studybbitback.domain.room.entity.roomboard.RoomBoardComment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class CreateRoomBoardCommentResponseDto {
+    private Long id;
+    private String content;
+    private String createdByNickname;
+    private LocalDateTime createdAt;
+    private Long roomBoardId;
+
+    public CreateRoomBoardCommentResponseDto(Long id, String content, String createdByNickname, LocalDateTime createdAt, Long roomBoardId) {
+        this.id = id;
+        this.content = content;
+        this.createdByNickname = createdByNickname;
+        this.createdAt = createdAt;
+        this.roomBoardId = roomBoardId;
+    }
+
+    // 정적 팩토리 메서드
+    public static CreateRoomBoardCommentResponseDto from(RoomBoardComment comment, String createdByNickname) {
+        return new CreateRoomBoardCommentResponseDto(
+                comment.getId(),
+                comment.getContent(),
+                createdByNickname,
+                comment.getCreatedAt(),
+                comment.getRoomBoard().getId()
+        );
+
+    }
+}
+

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/DeleteRoomBoardCommentRequestDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/DeleteRoomBoardCommentRequestDto.java
@@ -1,0 +1,4 @@
+package com.jungle.studybbitback.domain.room.dto.roomboardcomment;
+
+public class DeleteRoomBoardCommentRequestDto {
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/GetRoomBoardCommentResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/GetRoomBoardCommentResponseDto.java
@@ -1,0 +1,26 @@
+package com.jungle.studybbitback.domain.room.dto.roomboardcomment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class GetRoomBoardCommentResponseDto {
+    private Long id;
+    private String content;
+    private String createdBy;
+    private LocalDateTime createdAt;
+    private Long roomBoardId;
+
+    // 명시적으로 생성자 정의
+    public GetRoomBoardCommentResponseDto(Long id, String content, String createdBy, LocalDateTime createdAt, Long roomBoardId) {
+        this.id = id;
+        this.content = content;
+        this.createdBy = createdBy;
+        this.createdAt = createdAt;
+        this.roomBoardId = roomBoardId;
+    }
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/UpdateRoomBoardCommentRequestDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/UpdateRoomBoardCommentRequestDto.java
@@ -1,0 +1,17 @@
+package com.jungle.studybbitback.domain.room.dto.roomboardcomment;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateRoomBoardCommentRequestDto {
+
+    private String content;
+
+    @Builder
+    public UpdateRoomBoardCommentRequestDto(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/UpdateRoomBoardCommentResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/UpdateRoomBoardCommentResponseDto.java
@@ -1,0 +1,26 @@
+package com.jungle.studybbitback.domain.room.dto.roomboardcomment;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class UpdateRoomBoardCommentResponseDto {
+    private Long id;
+    private String content;
+    private String createdByNickname;
+    private LocalDateTime modifiedAt;
+    private Long roomBoardId;
+
+    @Builder
+    public UpdateRoomBoardCommentResponseDto(Long id, String content, String createdByNickname, LocalDateTime modifiedAt, Long roomBoardId) {
+        this.id = id;
+        this.content = content;
+        this.createdByNickname = createdByNickname;
+        this.modifiedAt = modifiedAt;
+        this.roomBoardId = getRoomBoardId();
+    }
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/entity/Room.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/entity/Room.java
@@ -1,9 +1,10 @@
 package com.jungle.studybbitback.domain.room.entity;
 
 import com.jungle.studybbitback.common.entity.ModifiedTimeEntity;
+
 import com.jungle.studybbitback.domain.room.dto.room.CreateRoomRequestDto;
 import com.jungle.studybbitback.domain.room.dto.room.UpdateRoomRequestDto;
-import com.jungle.studybbitback.domain.room.entity.roomboard.RoomBoard;
+
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -47,8 +48,9 @@ public class Room extends ModifiedTimeEntity {
     @Column(name = "meeting_id", columnDefinition = "UUID", unique = true)
     private UUID meetingId;
 
+    // Room과 연결된 RoomMember를 통해 참여한 Member들을 조회
     @OneToMany(mappedBy = "room")
-    private Set<RoomBoard> roomBoard = new HashSet<>();
+    private Set<RoomMember> roomMembers = new HashSet<>();
 
     public Room(CreateRoomRequestDto requestDto, Long memberId) {
         this.name = requestDto.getName();

--- a/src/main/java/com/jungle/studybbitback/domain/room/entity/roomboard/RoomBoard.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/entity/roomboard/RoomBoard.java
@@ -54,4 +54,12 @@ public class RoomBoard extends CreatedEntity {
                 .orElse("알 수 없음"); // 작성자를 찾을 수 없을 경우 기본값 반환
     }
 
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/entity/roomboard/RoomBoard.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/entity/roomboard/RoomBoard.java
@@ -10,6 +10,9 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -34,6 +37,8 @@ public class RoomBoard extends CreatedEntity {
     @Column(name = "created_by")  // createdBy를 Member와 연결
     private Long createdBy;  // 작성자는 Member 객체로 연결
 
+    @OneToMany(mappedBy = "roomBoard", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoomBoardComment> comments = new ArrayList<>();
 
     public RoomBoard(Room room, String title, String content, Long createdBy) {
         this.room = room;

--- a/src/main/java/com/jungle/studybbitback/domain/room/entity/roomboard/RoomBoardComment.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/entity/roomboard/RoomBoardComment.java
@@ -1,4 +1,52 @@
-//package com.jungle.studybbitback.domain.room.entity.roomboard;
-//
-//public class RoomBoardComment {
-//}
+package com.jungle.studybbitback.domain.room.entity.roomboard;
+
+import com.jungle.studybbitback.common.entity.ModifiedTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class RoomBoardComment extends ModifiedTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_board_comment_id")
+    private Long id;
+
+    @Column(name = "content", nullable = false, length = 255)
+    private String content;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_board_id")
+    private RoomBoard roomBoard;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void onPrePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // 생성자
+    @Builder
+    public RoomBoardComment(String content, Long createdBy, RoomBoard roomBoard) {
+        this.content = content;
+        this.createdBy = createdBy;
+        this.roomBoard = roomBoard;
+    }
+
+    // 댓글 수정
+    public void updateComment(String content) {
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/respository/RoomMemberRepository.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/respository/RoomMemberRepository.java
@@ -3,10 +3,13 @@ import com.jungle.studybbitback.domain.member.entity.Member;
 
 import com.jungle.studybbitback.domain.room.entity.Room;
 import com.jungle.studybbitback.domain.room.entity.RoomMember;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
 
@@ -24,4 +27,8 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
 
     // Room을 기준으로 RoomMember 삭제
     void deleteByRoom(Room room);
+
+
+    // 특정 Member에 속한 RoomMember를 페이지로 조회
+    Page<RoomMember> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/respository/RoomRepository.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/respository/RoomRepository.java
@@ -1,9 +1,14 @@
 package com.jungle.studybbitback.domain.room.respository;
+import com.jungle.studybbitback.domain.member.entity.Member;
 import com.jungle.studybbitback.domain.room.entity.Room;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
+    // 특정 이름 또는 상세 설명이 포함된 스터디룸 조회
     Page<Room> findByNameContainingOrDetailContaining(String nameKeyword, String detailKeyword, Pageable pageable);
+
+    // RoomMember를 통해 특정 Member가 속한 Room을 조회
+    Page<Room> findByRoomMembersMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/respository/roomboard/RoomBoardCommentRepository.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/respository/roomboard/RoomBoardCommentRepository.java
@@ -1,7 +1,11 @@
-//package com.jungle.studybbitback.domain.room.respository.roomboard;
-//
-//import com.jungle.studybbitback.domain.room.entity.Room;
-//import org.springframework.data.jpa.repository.JpaRepository;
-//
-//public interface RoomBoardCommentRepository extends JpaRepository<Room, Long> {
-//}
+
+package com.jungle.studybbitback.domain.room.respository.roomboard;
+
+import com.jungle.studybbitback.domain.room.entity.roomboard.RoomBoardComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomBoardCommentRepository extends JpaRepository<RoomBoardComment, Long> {
+    Page<RoomBoardComment> findByRoomBoardId(Long roomBoardId, Pageable pageable);
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/service/roomboard/RoomBoardCommentService.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/service/roomboard/RoomBoardCommentService.java
@@ -1,4 +1,103 @@
-//package com.jungle.studybbitback.domain.room.service.roomboard;
-//
-//public class RoomBoardCommentService {
-//}
+package com.jungle.studybbitback.domain.room.service.roomboard;
+
+import com.jungle.studybbitback.domain.member.repository.MemberRepository;
+import com.jungle.studybbitback.domain.room.dto.roomboardcomment.CreateRoomBoardCommentRequestDto;
+import com.jungle.studybbitback.domain.room.dto.roomboardcomment.CreateRoomBoardCommentResponseDto;
+import com.jungle.studybbitback.domain.room.dto.roomboardcomment.UpdateRoomBoardCommentRequestDto;
+import com.jungle.studybbitback.domain.room.dto.roomboardcomment.UpdateRoomBoardCommentResponseDto;
+import com.jungle.studybbitback.domain.room.entity.roomboard.RoomBoard;
+import com.jungle.studybbitback.domain.room.entity.roomboard.RoomBoardComment;
+import com.jungle.studybbitback.domain.room.respository.roomboard.RoomBoardCommentRepository;
+import com.jungle.studybbitback.domain.room.respository.roomboard.RoomBoardRepository;
+import com.jungle.studybbitback.domain.member.entity.Member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RoomBoardCommentService {
+
+    private final RoomBoardCommentRepository commentRepository;
+    private final RoomBoardRepository roomBoardRepository;
+    private final MemberRepository memberRepository;
+
+    // 댓글 작성
+    @Transactional
+    public CreateRoomBoardCommentResponseDto createComment(CreateRoomBoardCommentRequestDto requestDto, Long memberId) {
+        Long roomBoardId = requestDto.getRoomBoardId();
+
+        RoomBoard roomBoard = roomBoardRepository.findById(roomBoardId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        String content = requestDto.getContent();
+
+        // 댓글 엔티티 생성
+        RoomBoardComment comment = RoomBoardComment.builder()
+                .content(content)
+                .createdBy(memberId)
+                .roomBoard(roomBoard)
+                .build();
+
+        RoomBoardComment savedComment = commentRepository.save(comment);
+
+        String nickname = memberRepository.findById(memberId)
+                .map(Member::getNickname)
+                .orElse("Unknown");
+
+        return new CreateRoomBoardCommentResponseDto(
+                savedComment.getId(),
+                savedComment.getContent(),
+                nickname,
+                savedComment.getCreatedAt(),
+                roomBoardId);
+    }
+
+    // 댓글 수정
+    @Transactional
+    public UpdateRoomBoardCommentResponseDto updateComment(
+            Long commentId, UpdateRoomBoardCommentRequestDto requestDto, Long memberId
+    ) {
+        RoomBoardComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        // 작성자 검증
+        if (!comment.getCreatedBy().equals(memberId)) {
+            throw new IllegalAccessError("댓글 수정 권한이 없습니다.");
+        }
+
+        String newContent = requestDto.getContent();
+
+        comment.updateComment(newContent);
+        commentRepository.save(comment);
+
+
+        String nickname = memberRepository.findById(comment.getCreatedBy())
+                .map(Member::getNickname)
+                .orElse("Unknown");
+
+        return new UpdateRoomBoardCommentResponseDto(
+                comment.getId(),
+                comment.getContent(),
+                nickname,
+                comment.getModifiedAt(),
+                comment.getRoomBoard().getId());
+    }
+
+    // 댓글 삭제
+    @Transactional
+    public void deleteComment(Long commentId, Long memberId) {
+        RoomBoardComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        // 작성자 검증
+        if (!comment.getCreatedBy().equals(memberId)) {
+            throw new IllegalAccessError("댓글 삭제 권한이 없습니다.");
+        }
+
+        commentRepository.deleteById(commentId);
+    }
+
+}
+

--- a/src/main/java/com/jungle/studybbitback/domain/room/service/roomboard/RoomBoardService.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/service/roomboard/RoomBoardService.java
@@ -2,10 +2,7 @@ package com.jungle.studybbitback.domain.room.service.roomboard;
 
 import com.jungle.studybbitback.domain.member.entity.Member;
 import com.jungle.studybbitback.domain.member.repository.MemberRepository;
-import com.jungle.studybbitback.domain.room.dto.roomboard.CreateRoomBoardRequestDto;
-import com.jungle.studybbitback.domain.room.dto.roomboard.CreateRoomBoardResponseDto;
-import com.jungle.studybbitback.domain.room.dto.roomboard.GetRoomBoardDetailResponseDto;
-import com.jungle.studybbitback.domain.room.dto.roomboard.GetRoomBoardResponseDto;
+import com.jungle.studybbitback.domain.room.dto.roomboard.*;
 import com.jungle.studybbitback.domain.room.entity.Room;
 import com.jungle.studybbitback.domain.room.entity.roomboard.RoomBoard;
 import com.jungle.studybbitback.domain.room.entity.roomboard.RoomBoardComment;
@@ -102,7 +99,34 @@ public class RoomBoardService {
     }
 
     //스터디룸 게시글 수정
-    
+    @Transactional
+    public UpdateRoomBoardResponseDto updateRoomBoard(Long roomBoardId, UpdateRoomBoardRequestDto requestDto) {
+        RoomBoard roomBoard = roomBoardRepository.findById(roomBoardId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+
+        // 게시글 정보 업데이트
+        roomBoard.setTitle(requestDto.getTitle());
+        roomBoard.setContent(requestDto.getContent());
+
+        // 업데이트된 게시글 저장
+        roomBoardRepository.save(roomBoard);
+
+        // 응답 DTO 생성
+        return new UpdateRoomBoardResponseDto(roomBoard.getId(), roomBoard.getTitle(), roomBoard.getContent());
+    }
+
+    //스터디룸 게시글 삭제
+    @Transactional
+    public void deleteRoomBoard(Long roomBoardId) {
+        // 게시글을 데이터베이스에서 찾기
+        RoomBoard roomBoard = roomBoardRepository.findById(roomBoardId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+
+        // 게시글 삭제 - 연관된 댓글들도 자동으로 삭제됨 (Cascade 설정 필요)
+        roomBoardRepository.delete(roomBoard);
+    }
+
+
 
 
 }


### PR DESCRIPTION
1. 스터디룸 생성 시 프로필이미지 관련 설정 제외 CRUD 구현(페이징처리)

2. 스터디룸 게시글 댓글 구현(페이징 처리)

3. 내 스터디 조회(페이징 처리)
: 스터디 조회 기본 단위 4개로 두고, 좌우 화살표 누르면 로드되게


🚩<추후 수정 필요한 부분>
- 방 제목 입력하면 자동으로 유니크한 url 자동 생성하기(방 제목과 마찬가지로 수정 불가능)
- Url을 직접 생성 가능하게 하든 아니든 공백이나 특수문자 처리하기