### PR TITLE
fix. 스터디룸 상세정보 api에서 프사 노출, 게시글에서 프사 컬럼명 통일

### DIFF
--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/room/GetRoomDetailResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/room/GetRoomDetailResponseDto.java
@@ -13,8 +13,9 @@ public class GetRoomDetailResponseDto {
     private String profileImageUrl;
     private boolean isPrivate;
     private String leaderNickname;
+    private String leaderImageUrl;
 
-    public GetRoomDetailResponseDto(Room room, String leaderNickname) {
+    public GetRoomDetailResponseDto(Room room, String leaderNickname, String leaderImageUrl) {
         this.id = room.getId();
         this.name = room.getName();
         this.detail = room.getDetail();
@@ -23,6 +24,7 @@ public class GetRoomDetailResponseDto {
         this.profileImageUrl = room.getProfileImageUrl();
         this.isPrivate = room.isPrivate();
         this.leaderNickname = leaderNickname;
+        this.leaderImageUrl = leaderImageUrl;
     }
 
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/GetRoomBoardResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/GetRoomBoardResponseDto.java
@@ -16,7 +16,7 @@ public class GetRoomBoardResponseDto {
     private String title;
     private String content;
     private String createdBy;
-    private String profileImageUrl;
+    private String createdByProfileUrl;
     private LocalDateTime createdAt;
     private Long roomId;
 

--- a/src/main/java/com/jungle/studybbitback/domain/room/service/RoomService.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/service/RoomService.java
@@ -111,12 +111,15 @@ public class RoomService {
         Room room = roomRepository.findById(id).orElseThrow(
                 () -> new IllegalArgumentException("존재하지 않는 방입니다.")
         );
-        // leaderId를 통해 방장의 닉네임 조회
-        String leaderNickname = memberRepository.findById(room.getLeaderId())
-                .orElseThrow(() -> new IllegalArgumentException("방장이 존재하지 않습니다."))
-                .getNickname();
+        // leaderId를 통해 방장 정보 조회
+        Member leader = memberRepository.findById(room.getLeaderId())
+                .orElseThrow(() -> new IllegalArgumentException("방장이 존재하지 않습니다."));
 
-        return new GetRoomDetailResponseDto(room, leaderNickname);
+        // 닉네임과 프로필 이미지를 조회
+        String leaderNickname = leader.getNickname();
+        String leaderImageUrl = leader.getProfileImageUrl();
+
+        return new GetRoomDetailResponseDto(room, leaderNickname, leaderImageUrl);
     }
 
     // 대시보드 접근 시 멤버 여부 확인


### PR DESCRIPTION
스터디룸 상세정보에서도 방장 프사 노출되게 수정

스터디룸 내부에서 게시글, 댓글 작성자 프로필 이미지 컬럼명 통일 (createdByProfileUrl)