### PR TITLE
스터디 일정 수정 및 삭제

### DIFF
--- a/src/main/java/com/jungle/studybbitback/common/utils/DateUtils.java
+++ b/src/main/java/com/jungle/studybbitback/common/utils/DateUtils.java
@@ -4,8 +4,10 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.TextStyle;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -21,6 +23,11 @@ public class DateUtils {
             "토", DayOfWeek.SATURDAY,
             "일", DayOfWeek.SUNDAY
     );
+
+    // 요일 한국어 표기 단일단위
+    public static String getDayInKorean(DayOfWeek day) {
+        return day.getDisplayName(TextStyle.FULL, Locale.KOREAN);
+    }
 
     /**
      * 한국어 요일 문자열을 DayOfWeek 리스트로 변환.

--- a/src/main/java/com/jungle/studybbitback/domain/room/controller/schedule/ScheduleController.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/controller/schedule/ScheduleController.java
@@ -1,9 +1,6 @@
 package com.jungle.studybbitback.domain.room.controller.schedule;
 
-import com.jungle.studybbitback.domain.room.dto.schedule.CreateScheduleRequestDto;
-import com.jungle.studybbitback.domain.room.dto.schedule.CreateScheduleResponseDto;
-import com.jungle.studybbitback.domain.room.dto.schedule.GetScheduleDetailResponseDto;
-import com.jungle.studybbitback.domain.room.dto.schedule.GetScheduleResponseDto;
+import com.jungle.studybbitback.domain.room.dto.schedule.*;
 import com.jungle.studybbitback.domain.room.service.schedule.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/schedule")
@@ -29,7 +27,7 @@ public class ScheduleController {
         return ResponseEntity.status(201).body(response);
     }
 
-    /*** 전체 일정 조회* GET /api/schedules?roomId={roomId}&page={page}&size={size}*/
+    // 전체 일정 조회
     @GetMapping("/{roomId}")
     public ResponseEntity<Page<GetScheduleResponseDto>> getAllSchedules(
             @PathVariable Long roomId,
@@ -37,28 +35,6 @@ public class ScheduleController {
         Page<GetScheduleResponseDto> schedules = scheduleService.getAllSchedules(roomId, pageable);
         return ResponseEntity.ok(schedules);
     }
-
-
-//    // 일정 전체 조회
-//    @GetMapping("/{roomId}")
-//    public ResponseEntity<Page<GetScheduleResponseDto>> getSchedules(
-//            @PathVariable Long roomId,
-//            @RequestParam(required = false) Integer year,
-//            @RequestParam(required = false) Integer month,
-//            @RequestParam(required = false, defaultValue = "0") int page,
-//            @RequestParam(required = false, defaultValue = "5") int size,
-//            Pageable pageable) {
-//        // year와 month가 null인 경우 기본값 설정
-//        if (year == null) {
-//            year = LocalDate.now().getYear(); // 기본값: 현재 연도
-//        }
-//        if (month == null) {
-//            month = LocalDate.now().getMonthValue(); // 기본값: 현재 월
-//        }
-//
-//        Page<GetScheduleResponseDto> schedules = scheduleService.getSchedulesByMonth(roomId, year, month, pageable);
-//        return ResponseEntity.ok(schedules);
-//    }
 
     //일정 상세 조회
     @GetMapping("/detail/{scheduleId}")
@@ -69,6 +45,25 @@ public class ScheduleController {
         GetScheduleDetailResponseDto scheduleDetail = scheduleService.getScheduleDetail(scheduleId, commentPageable);
         return ResponseEntity.ok(scheduleDetail);
 
+    }
+
+    // 단일 일정 수정
+    @PostMapping("/single/{scheduleId}")
+    public ResponseEntity<UpdateScheduleResponseDto> updateSingleSchedule(
+            @PathVariable Long scheduleId,
+            @RequestBody UpdateScheduleRequestDto updateScheduleRequestDto) {
+        UpdateScheduleResponseDto responseDto = scheduleService.updateSingleSchedule(scheduleId, updateScheduleRequestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 일정 전체 수정
+    @PostMapping("/all/{scheduleCycleId}")
+    public ResponseEntity<List<UpdateAllScheduleResponseDto>> updateAllSchedule(
+            @PathVariable Long scheduleCycleId,
+            @RequestBody UpdateAllScheduleRequestDto updateAllRequestDto,
+            Pageable pageable) {
+        List<UpdateAllScheduleResponseDto> responseDto = scheduleService.updateAllSchedule(scheduleCycleId, updateAllRequestDto, pageable);
+        return ResponseEntity.ok(responseDto);
     }
 
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/controller/schedule/ScheduleController.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/controller/schedule/ScheduleController.java
@@ -66,4 +66,18 @@ public class ScheduleController {
         return ResponseEntity.ok(responseDto);
     }
 
+    // 단일 일정 삭제
+    @DeleteMapping("/single/{scheduleId}")
+    public ResponseEntity<String> deleteSingleSchedule(@PathVariable Long scheduleId) {
+        scheduleService.deleteSingleSchedule(scheduleId);
+        return ResponseEntity.ok("해당 날짜의 일정이 삭제되었습니다.");
+    }
+
+    // 반복 일정 전체 삭제
+    @DeleteMapping("/all/{scheduleCycleId}")
+    public ResponseEntity<String> deleteAllSchedule(@PathVariable Long scheduleCycleId) {
+        scheduleService.deleteAllSchedule(scheduleCycleId);
+        return ResponseEntity.ok("주간 반복 일정 전체가 삭제되었습니다.");
+    }
+
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/CreateScheduleResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/CreateScheduleResponseDto.java
@@ -1,5 +1,6 @@
 package com.jungle.studybbitback.domain.room.dto.schedule;
 
+import com.jungle.studybbitback.common.utils.DateUtils;
 import com.jungle.studybbitback.domain.room.entity.schedule.Schedule;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ public class CreateScheduleResponseDto {
     private Long scheduleId;
     private String title;
     private LocalDate startDate; // 시작 날짜
+    private String day;
     private LocalTime startTime;  // 시작 시간
     private LocalTime endTime;    // 종료 시간
     private String detail;
@@ -30,6 +32,7 @@ public class CreateScheduleResponseDto {
                 .scheduleId(schedule.getId())
                 .title(schedule.getTitle())
                 .startDate(schedule.getStartDate())
+                .day(DateUtils.getDayInKorean(schedule.getStartDate().getDayOfWeek()))
                 .startTime(schedule.getStartDateTime().toLocalTime())
                 .endTime(schedule.getEndDateTime().toLocalTime())
                 .detail(schedule.getDetail())

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/GetScheduleDetailResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/GetScheduleDetailResponseDto.java
@@ -1,16 +1,12 @@
 package com.jungle.studybbitback.domain.room.dto.schedule;
 
-import com.jungle.studybbitback.domain.room.dto.schedulemember.GetScheduleMemberResponseDto;
+import com.jungle.studybbitback.common.utils.DateUtils;
 import com.jungle.studybbitback.domain.room.entity.schedule.Schedule;
-import com.jungle.studybbitback.domain.room.entity.schedule.ScheduleMember;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -18,6 +14,7 @@ public class GetScheduleDetailResponseDto {
     private Long scheduleId;
     private String title;
     private LocalDate startDate; // 시작 날짜
+    private String day;
     private LocalTime startTime;  // 시작 시간
     private LocalTime endTime;    // 종료 시간
     private String detail;
@@ -35,6 +32,7 @@ public class GetScheduleDetailResponseDto {
                 .scheduleId(schedule.getId())
                 .title(schedule.getTitle())
                 .startDate(schedule.getStartDate())
+                .day(DateUtils.getDayInKorean(schedule.getStartDate().getDayOfWeek())) // 단일 일정 요일 추가
                 .startTime(schedule.getStartDateTime().toLocalTime())
                 .endTime(schedule.getEndDateTime().toLocalTime())
                 .detail(schedule.getDetail())

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/GetScheduleResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/GetScheduleResponseDto.java
@@ -1,11 +1,11 @@
 package com.jungle.studybbitback.domain.room.dto.schedule;
 
+import com.jungle.studybbitback.common.utils.DateUtils;
 import com.jungle.studybbitback.domain.room.entity.schedule.Schedule;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter
@@ -14,6 +14,7 @@ public class GetScheduleResponseDto {
     private Long scheduleId;
     private String title;
     private LocalDate startDate; // 시작 날짜
+    private String day;
     private LocalTime startTime;  // 시작 시간
     private LocalTime endTime;    // 종료 시간
     private String detail;
@@ -30,6 +31,7 @@ public class GetScheduleResponseDto {
                 .scheduleId(schedule.getId())
                 .title(schedule.getTitle())
                 .startDate(schedule.getStartDate())
+                .day(DateUtils.getDayInKorean(schedule.getStartDate().getDayOfWeek())) // 단일 일정 요일 추가
                 .startTime(schedule.getStartDateTime().toLocalTime())
                 .endTime(schedule.getEndDateTime().toLocalTime())
                 .detail(schedule.getDetail())

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateAllScheduleResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateAllScheduleResponseDto.java
@@ -1,11 +1,11 @@
 package com.jungle.studybbitback.domain.room.dto.schedule;
 
+import com.jungle.studybbitback.common.utils.DateUtils;
 import com.jungle.studybbitback.domain.room.entity.schedule.Schedule;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter
@@ -15,6 +15,7 @@ public class UpdateAllScheduleResponseDto {
     private String title;
     private String detail;
     private LocalDate startDate; // 시작 날짜
+    private String day;
     private LocalTime startTime;  // 시작 시간
     private LocalTime endTime;    // 종료 시간
     private boolean repeatFlag;
@@ -29,6 +30,7 @@ public class UpdateAllScheduleResponseDto {
         this.title = schedule.getTitle();
         this.detail = schedule.getDetail();
         this.startDate = schedule.getStartDate();
+        this.day = DateUtils.getDayInKorean(schedule.getStartDate().getDayOfWeek());
         this.startTime = schedule.getStartDateTime().toLocalTime();
         this.endTime = schedule.getEndDateTime().toLocalTime();
         this.repeatFlag = schedule.isRepeatFlag();

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateScheduleRequestDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateScheduleRequestDto.java
@@ -1,4 +1,49 @@
 package com.jungle.studybbitback.domain.room.dto.schedule;
 
+
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@ToString
 public class UpdateScheduleRequestDto {
+    private String title;
+    private String detail;
+    private LocalDate startDate;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private boolean repeatFlag;
+    private String repeatPattern;
+    private String daysOfWeek;
+    private LocalDate repeatEndDate;
+
+    @Builder
+    public UpdateScheduleRequestDto(String title, String detail, LocalDate startDate, LocalTime startTime,
+                                    LocalTime endTime, boolean repeatFlag, String repeatPattern, String daysOfWeek,
+                                    LocalDate repeatEndDate) {
+        this.title = title;
+        this.detail = detail;
+        this.startDate = startDate;
+        this.startTime = (startTime != null) ? startTime : LocalTime.of(0, 0);
+        this.endTime = (endTime != null) ? endTime : LocalTime.of(23, 59);
+        this.repeatFlag = repeatFlag;
+        this.repeatPattern = repeatPattern;
+        this.daysOfWeek = daysOfWeek;
+        this.repeatEndDate = repeatEndDate;
+    }
+
+    // startDate와 startTime을 합쳐서 LocalDateTime 반환
+    public LocalDateTime getStartDateTime() {
+        return this.startDate.atTime(this.startTime);
+    }
+
+    // startDate와 endTime을 합쳐서 LocalDateTime 반환
+    public LocalDateTime getEndDateTime() {
+        return this.startDate.atTime(this.endTime);
+    }
+
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateScheduleResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateScheduleResponseDto.java
@@ -1,4 +1,43 @@
 package com.jungle.studybbitback.domain.room.dto.schedule;
 
+import com.jungle.studybbitback.common.utils.DateUtils;
+import com.jungle.studybbitback.domain.room.entity.schedule.Schedule;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
 public class UpdateScheduleResponseDto {
+    private Long scheduleId;
+    private String title;
+    private String detail;
+    private LocalDate startDate; // 시작 날짜
+    private String day;
+    private LocalTime startTime;  // 시작 시간
+    private LocalTime endTime;    // 종료 시간
+    private boolean repeatFlag;
+    private String repeatPattern;
+    private String daysOfWeek;
+    private LocalDate repeatEndDate;
+    private Long scheduleCycleId; //단일일정은 null로 받음 & 반복 일정에서 하루만 수정하면 역시 null로 옴
+
+    // Schedule 엔터티를 기반으로 DTO를 생성하는 생성자
+    public UpdateScheduleResponseDto(Schedule schedule) {
+        this.scheduleId = schedule.getId();
+        this.title = schedule.getTitle();
+        this.detail = schedule.getDetail();
+        this.startDate = schedule.getStartDate();
+        this.day = DateUtils.getDayInKorean(schedule.getStartDate().getDayOfWeek());
+        this.startTime = schedule.getStartDateTime().toLocalTime();
+        this.endTime = schedule.getEndDateTime().toLocalTime();
+        this.repeatFlag = schedule.isRepeatFlag();
+        this.repeatPattern = schedule.getRepeatPattern();
+        this.daysOfWeek = schedule.getDaysOfWeek();
+        this.repeatEndDate = schedule.getRepeatEndDate();
+        this.scheduleCycleId = schedule.getScheduleCycleId();
+    }
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/entity/schedule/Schedule.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/entity/schedule/Schedule.java
@@ -6,6 +6,7 @@ import com.jungle.studybbitback.domain.room.dto.schedule.CreateScheduleRequestDt
 import com.jungle.studybbitback.domain.room.entity.Room;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +20,8 @@ import org.springframework.cglib.core.Local;
 @Entity
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Schedule extends ModifiedTimeEntity {
 
     @Id
@@ -87,6 +90,29 @@ public class Schedule extends ModifiedTimeEntity {
         schedule.daysOfWeek = requestDto.getDaysOfWeek();
         schedule.repeatEndDate = requestDto.getRepeatEndDate();
         return schedule;
+    }
+
+    public void updateDetails(String title, String detail, LocalDate startDate, LocalDateTime startTime, LocalDateTime endTime,
+                              Boolean repeatFlag, String repeatPattern, String daysOfWeek, LocalDate repeatEndDate) {
+        if(title != null) this.title = title;
+        if(detail != null) this.detail = detail;
+        if(startDate != null){
+            this.startDate = startDate;
+            this.startDateTime = startTime;
+            // endDateTime이 null이면 기본값을 설정하거나 예외를 던질 수 있습니다
+            if (endTime != null) {
+                this.endDateTime = endTime;
+            } else {
+                // 기본값을 설정하거나 예외 처리
+                throw new IllegalArgumentException("종료시간은 필수로 입력되어야 합니다.");
+            }
+        }
+        if(repeatFlag != null){
+            this.repeatFlag = repeatFlag;
+            this.repeatPattern = repeatPattern;
+            this.daysOfWeek = daysOfWeek;
+            this.repeatEndDate = repeatEndDate;
+        }
     }
 
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/service/schedule/ScheduleService.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/service/schedule/ScheduleService.java
@@ -4,10 +4,7 @@ import com.jungle.studybbitback.common.utils.DateUtils;
 import com.jungle.studybbitback.domain.member.entity.Member;
 import com.jungle.studybbitback.domain.member.repository.MemberRepository;
 import com.jungle.studybbitback.domain.room.controller.schedule.ScheduleCycleIdGenerator;
-import com.jungle.studybbitback.domain.room.dto.schedule.CreateScheduleRequestDto;
-import com.jungle.studybbitback.domain.room.dto.schedule.CreateScheduleResponseDto;
-import com.jungle.studybbitback.domain.room.dto.schedule.GetScheduleDetailResponseDto;
-import com.jungle.studybbitback.domain.room.dto.schedule.GetScheduleResponseDto;
+import com.jungle.studybbitback.domain.room.dto.schedule.*;
 import com.jungle.studybbitback.domain.room.entity.Room;
 import com.jungle.studybbitback.domain.room.entity.schedule.Schedule;
 import com.jungle.studybbitback.domain.room.respository.RoomMemberRepository;
@@ -26,7 +23,12 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.jungle.studybbitback.domain.room.entity.QRoom.room;
 
 @Service
 @RequiredArgsConstructor
@@ -131,8 +133,8 @@ public class ScheduleService {
             throw new IllegalStateException("일정 생성에 실패하였습니다.");
         }
     }
-    // isRepeatFlag = True이면 주간반복 일정 생성
 
+    // isRepeatFlag = True이면 주간반복 일정 생성
     private Schedule createRecurringSchedules(Schedule initialSchedule, CreateScheduleRequestDto requestDto,
                                               LocalDateTime startDateTime, LocalDateTime endDateTime,
                                               Room room, Member member, Long scheduleCycleId) {
@@ -207,6 +209,7 @@ public class ScheduleService {
         return firstRecurringSchedule;
     }
 
+    // 일정 전체 조회
     @Transactional
     public Page<GetScheduleResponseDto> getAllSchedules(Long roomId, Pageable pageable) {
         CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -219,7 +222,7 @@ public class ScheduleService {
         return schedules.map(GetScheduleResponseDto::from);
     }
 
-
+    //일정 상세 조회
     @Transactional(readOnly = true)
     public GetScheduleDetailResponseDto getScheduleDetail(Long scheduleId, Pageable commentPageable) {
         CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -239,23 +242,111 @@ public class ScheduleService {
 
         // TODO: 출석부 로직 추가
 
-        return GetScheduleDetailResponseDto.builder()
-                .scheduleId(schedule.getId())
-                .title(schedule.getTitle())
-                .startDate(schedule.getStartDate())
-                .startTime(schedule.getStartDateTime().toLocalTime())
-                .endTime(schedule.getEndDateTime().toLocalTime())
-                .detail(schedule.getDetail())
-                .roomId(schedule.getRoom().getId())
-                .creatorName(schedule.getCreatedBy().getNickname())
-                .repeatFlag(schedule.isRepeatFlag())
-                .repeatPattern(schedule.getRepeatPattern())
-                .daysOfWeek(schedule.getDaysOfWeek())
-                .repeatEndDate(schedule.getRepeatEndDate() != null ? schedule.getRepeatEndDate().toString() : null)
-                .scheduleCycleId(schedule.getScheduleCycleId())
-                .build();
+        return GetScheduleDetailResponseDto.from(schedule);
     }
 
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+    //단일 일정 수정
+    @Transactional
+    public UpdateScheduleResponseDto updateSingleSchedule(Long scheduleId, UpdateScheduleRequestDto updateScheduleRequestDto) {
+        // 인증된 사용자 정보 가져오기
+        CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Long memberId = userDetails.getMemberId();
 
+        // 일정 조회
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정이 존재하지 않습니다."));
+
+        // 방 멤버 여부 검증
+        Long roomId = schedule.getRoom().getId();
+        validateRoomMembership(roomId, memberId);
+
+        // 단일 일정 여부 체크
+        if (schedule.getScheduleCycleId() != null) {
+            // 반복 일정에서 특정 하루만 수정하려는 경우
+            schedule.setScheduleCycleId(null); // 단일 일정으로 변경
+            log.info("단일 일정으로 수정됨: scheduleId={}", scheduleId);
+        } else {
+            // 애초에 단일 일정인 경우
+            log.info("이미 단일 일정입니다. 수정이 불필요합니다.");
+        }
+
+        // 일정 수정
+        schedule.updateDetails(
+                updateScheduleRequestDto.getTitle(),
+                updateScheduleRequestDto.getDetail(),
+                updateScheduleRequestDto.getStartDate(),
+                updateScheduleRequestDto.getStartDateTime(),
+                updateScheduleRequestDto.getEndDateTime(),
+                updateScheduleRequestDto.isRepeatFlag(),
+                updateScheduleRequestDto.getRepeatPattern(),
+                updateScheduleRequestDto.getDaysOfWeek(),
+                updateScheduleRequestDto.getRepeatEndDate()
+        );
+
+        scheduleRepository.save(schedule);
+        log.info("수정된 단일 일정: {}", schedule);
+
+        return new UpdateScheduleResponseDto(schedule);
+    }
+
+    // 전체 일정 수정
+    @Transactional
+    public List<UpdateAllScheduleResponseDto> updateAllSchedule(Long scheduleCycleId, UpdateAllScheduleRequestDto requestDto, Pageable pageable) {
+        CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Long memberId = userDetails.getMemberId();
+
+        // 해당 스케줄 사이클에 속한 일정들 조회
+        Page<Schedule> existingSchedules = scheduleRepository.findByScheduleCycleId(scheduleCycleId, pageable);
+
+        if (existingSchedules.isEmpty()) {
+            throw new IllegalArgumentException("해당 반복 일정이 존재하지 않습니다.");
+        }
+
+        // 스터디룸 멤버 여부 확인
+        Long roomId = existingSchedules.getContent().get(0).getRoom().getId();
+        validateRoomMembership(roomId, memberId);
+
+        // 기존 일정 삭제
+        existingSchedules.forEach(schedule -> {
+            log.info("삭제할 scheduleId {}", schedule.getId());
+            scheduleRepository.delete(schedule);
+        });
+
+        // 새로운 요일과 날짜에 따른 일정 생성
+        List<DayOfWeek> newDaysOfWeek = DateUtils.parseDaysOfWeek(requestDto.getDaysOfWeek());
+        List<Schedule> newSchedules = new ArrayList<>();
+
+        LocalDate current = requestDto.getStartDate();
+
+        while (!current.isAfter(requestDto.getRepeatEndDate())) { // 반복종료날짜 초과 시 더이상 일정을 생성하지 않음
+            if (newDaysOfWeek.contains(current.getDayOfWeek())) {
+                LocalDateTime startDateTime = current.atTime(requestDto.getStartTime());
+                LocalDateTime endDateTime = current.atTime(requestDto.getEndTime());
+                Schedule newSchedule = Schedule.builder()
+                        .title(requestDto.getTitle())
+                        .detail(requestDto.getDetail())
+                        .startDate(current)
+                        .startDateTime(startDateTime)
+                        .endDateTime(endDateTime)
+                        .repeatFlag(requestDto.isRepeatFlag())
+                        .repeatPattern(requestDto.getRepeatPattern())
+                        .daysOfWeek(requestDto.getDaysOfWeek())
+                        .repeatEndDate(requestDto.getRepeatEndDate())
+                        .room(roomRepository.findById(roomId).orElseThrow())
+                        .createdBy(memberRepository.findById(memberId).orElseThrow())
+                        .scheduleCycleId(scheduleCycleId)
+                        .build();
+                scheduleRepository.save(newSchedule);
+                newSchedules.add(newSchedule);
+                log.info("일괄 수정 : 새롭게 생성된 반복 일정 제목 :: {} 시작날짜 :{}", newSchedule.getTitle(), current);
+            }
+            current = current.plusDays(1);
+        }
+
+        return newSchedules.stream()
+                .map(UpdateAllScheduleResponseDto::new)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/service/schedule/ScheduleService.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/service/schedule/ScheduleService.java
@@ -349,4 +349,20 @@ public class ScheduleService {
                 .map(UpdateAllScheduleResponseDto::new)
                 .collect(Collectors.toList());
     }
+
+    // 단일 일정 삭제
+    @Transactional
+    public void deleteSingleSchedule(Long scheduleId){
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(()-> new IllegalArgumentException("해당 일정은 존재하지 않습니다."));
+
+        // 단일 일정 삭제
+        scheduleRepository.delete(schedule);
+    }
+
+    // 반복 일정 일괄 삭제 (단일로 된 일정을 일괄로 삭제하는 게 아님!)
+    @Transactional
+    public  void deleteAllSchedule(Long scheduleCycleId){
+        scheduleRepository.deleteByScheduleCycleId(scheduleCycleId);
+    }
 }


### PR DESCRIPTION
[스터디 일정]

1. 하루씩만 수정
: 반복일정 중 하루를 골라서 수정할 경우,  scheduleCycleId 값이 null이 되고, 반복일정에 속하지 않게 됩니다.

2. 반복일정 전체 수정 : 기존의 일정을 삭제하고 새로 생성하므로 기존에 부여된 scheduleId 값이 변경됩니다.
*scheduleCycleId는 그대로 유지됩니다.


3. 하루만 삭제

4. 반복일정 전체 삭제(단일 일정 여러 개를 일괄 삭제하는 기능이 아닙니다.)