### PR TITLE
Hjh/schedule/comment

### DIFF
--- a/src/main/java/com/jungle/studybbitback/common/utils/DateUtils.java
+++ b/src/main/java/com/jungle/studybbitback/common/utils/DateUtils.java
@@ -26,7 +26,17 @@ public class DateUtils {
 
     // 요일 한국어 표기 단일단위
     public static String getDayInKorean(DayOfWeek day) {
-        return day.getDisplayName(TextStyle.FULL, Locale.KOREAN);
+        // 요일을 축약 형태로 반환
+        switch (day) {
+            case MONDAY: return "월";
+            case TUESDAY: return "화";
+            case WEDNESDAY: return "수";
+            case THURSDAY: return "목";
+            case FRIDAY: return "금";
+            case SATURDAY: return "토";
+            case SUNDAY: return "일";
+            default: throw new IllegalArgumentException("Invalid day of the week");
+        }
     }
 
     /**

--- a/src/main/java/com/jungle/studybbitback/domain/room/controller/schedule/ScheduleController.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/controller/schedule/ScheduleController.java
@@ -66,6 +66,15 @@ public class ScheduleController {
         return ResponseEntity.ok(responseDto);
     }
 
+    // 반복 일정 수정 중 이후 일정들에 대해서만 수정 ***********************************
+    @PostMapping("/upcoming/{scheduleCycleId}")
+    public ResponseEntity<List<UpdateUpcomingScheduleResponseDto>> updateUpcomingSchedules(
+            @PathVariable Long scheduleCycleId,
+            @RequestBody UpdateUpcomingScheduleRequestDto requestDto) {
+        List<UpdateUpcomingScheduleResponseDto> responseDto = scheduleService.updateUpcomingSchedules(scheduleCycleId, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
     // 단일 일정 삭제
     @DeleteMapping("/single/{scheduleId}")
     public ResponseEntity<String> deleteSingleSchedule(@PathVariable Long scheduleId) {
@@ -79,5 +88,7 @@ public class ScheduleController {
         scheduleService.deleteAllSchedule(scheduleCycleId);
         return ResponseEntity.ok("주간 반복 일정 전체가 삭제되었습니다.");
     }
+
+
 
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/controller/schedule/ScheduleController.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/controller/schedule/ScheduleController.java
@@ -89,6 +89,15 @@ public class ScheduleController {
         return ResponseEntity.ok("주간 반복 일정 전체가 삭제되었습니다.");
     }
 
+    // 특정 시점 이후의 일정들만 삭제
+    @DeleteMapping("/upcoming/{scheduleCycleId}")
+    public ResponseEntity<String> deleteUpcomingSchedulesAfterDate(
+            @PathVariable Long scheduleCycleId,
+            @RequestBody UpdateUpcomingScheduleRequestDto requestDto) {
+        scheduleService.deleteUpcomingSchedules(scheduleCycleId, requestDto);
+        return ResponseEntity.ok("삭제 시작일 이후의 일정들이 삭제되었습니다.");
+    }
+
 
 
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/CreateScheduleRequestDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/CreateScheduleRequestDto.java
@@ -14,6 +14,7 @@ public class CreateScheduleRequestDto {
     private Long roomId;
     private String title;
     private LocalDate startDate; // 시작 날짜
+    private String day;
     private LocalTime startTime;  // 시작 시간
     private LocalTime endTime;    // 종료 시간
     private String detail;
@@ -25,11 +26,12 @@ public class CreateScheduleRequestDto {
 
 
     @Builder
-    public CreateScheduleRequestDto(Long roomId, String title, LocalDate startDate, LocalTime startTime, LocalTime endTime, String detail,
+    public CreateScheduleRequestDto(Long roomId, String title, LocalDate startDate, String day, LocalTime startTime, LocalTime endTime, String detail,
                                     boolean repeatFlag, String repeatPattern, String daysOfWeek, LocalDate repeatEndDate, Long scheduleCycleId) {
         this.roomId = roomId;
         this.title = title;
         this.startDate = startDate;
+        this.day = day;
         this.startTime = (startTime != null) ? startTime : LocalTime.of(0,0);
         this.endTime = (endTime != null) ? endTime : LocalTime.of(23,59);
         this.detail = detail;

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateAllScheduleRequestDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateAllScheduleRequestDto.java
@@ -12,6 +12,7 @@ public class UpdateAllScheduleRequestDto {
     private String title;
     private String detail;
     private LocalDate startDate;
+    private String day;
     private LocalTime startTime;
     private LocalTime endTime;
     private boolean repeatFlag;
@@ -20,12 +21,13 @@ public class UpdateAllScheduleRequestDto {
     private LocalDate repeatEndDate;
 
     @Builder
-    public UpdateAllScheduleRequestDto(String title, String detail, LocalDate startDate, LocalTime startTime,
+    public UpdateAllScheduleRequestDto(String title, String detail, LocalDate startDate, String day, LocalTime startTime,
                                     LocalTime endTime, boolean repeatFlag, String repeatPattern, String daysOfWeek,
                                     LocalDate repeatEndDate) {
         this.title = title;
         this.detail = detail;
         this.startDate = startDate;
+        this.day = day;
         this.startTime = (startTime != null) ? startTime : LocalTime.of(0, 0);
         this.endTime = (endTime != null) ? endTime : LocalTime.of(23, 59);
         this.repeatFlag = repeatFlag;

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateScheduleRequestDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateScheduleRequestDto.java
@@ -14,6 +14,7 @@ public class UpdateScheduleRequestDto {
     private String title;
     private String detail;
     private LocalDate startDate;
+    private String day;
     private LocalTime startTime;
     private LocalTime endTime;
     private boolean repeatFlag;
@@ -22,12 +23,13 @@ public class UpdateScheduleRequestDto {
     private LocalDate repeatEndDate;
 
     @Builder
-    public UpdateScheduleRequestDto(String title, String detail, LocalDate startDate, LocalTime startTime,
+    public UpdateScheduleRequestDto(String title, String detail, LocalDate startDate, String day, LocalTime startTime,
                                     LocalTime endTime, boolean repeatFlag, String repeatPattern, String daysOfWeek,
                                     LocalDate repeatEndDate) {
         this.title = title;
         this.detail = detail;
         this.startDate = startDate;
+        this.day = day;
         this.startTime = (startTime != null) ? startTime : LocalTime.of(0, 0);
         this.endTime = (endTime != null) ? endTime : LocalTime.of(23, 59);
         this.repeatFlag = repeatFlag;

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateUpcomingScheduleRequestDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateUpcomingScheduleRequestDto.java
@@ -1,0 +1,51 @@
+package com.jungle.studybbitback.domain.room.dto.schedule;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class UpdateUpcomingScheduleRequestDto {
+    private String title;
+    private String detail;
+    private LocalDate startDate;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private boolean repeatFlag;
+    private String repeatPattern;
+    private String daysOfWeek;
+    private LocalDate repeatEndDate;
+
+    @Builder
+    public UpdateUpcomingScheduleRequestDto(String title, String detail, LocalDate startDate, LocalTime startTime,
+                                            LocalTime endTime, boolean repeatFlag, String repeatPattern, String daysOfWeek,
+                                            LocalDate repeatEndDate) {
+        this.title = title;
+        this.detail = detail;
+        this.startDate = startDate;
+        this.startTime = (startTime != null) ? startTime : LocalTime.of(0, 0);
+        this.endTime = (endTime != null) ? endTime : LocalTime.of(23, 59);
+        this.repeatFlag = repeatFlag;
+        this.repeatPattern = repeatPattern;
+        this.daysOfWeek = daysOfWeek;
+        this.repeatEndDate = repeatEndDate;
+    }
+
+    // startDate와 startTime을 합쳐서 LocalDateTime 반환
+    public LocalDateTime getStartDateTime() {
+        return this.startDate.atTime(this.startTime);
+    }
+
+    // startDate와 endTime을 합쳐서 LocalDateTime 반환
+    public LocalDateTime getEndDateTime() {
+        return this.startDate.atTime(this.endTime);
+    }
+
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateUpcomingScheduleRequestDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateUpcomingScheduleRequestDto.java
@@ -16,6 +16,7 @@ public class UpdateUpcomingScheduleRequestDto {
     private String title;
     private String detail;
     private LocalDate startDate;
+    private String day;
     private LocalTime startTime;
     private LocalTime endTime;
     private boolean repeatFlag;
@@ -24,12 +25,13 @@ public class UpdateUpcomingScheduleRequestDto {
     private LocalDate repeatEndDate;
 
     @Builder
-    public UpdateUpcomingScheduleRequestDto(String title, String detail, LocalDate startDate, LocalTime startTime,
+    public UpdateUpcomingScheduleRequestDto(String title, String detail, LocalDate startDate, String day, LocalTime startTime,
                                             LocalTime endTime, boolean repeatFlag, String repeatPattern, String daysOfWeek,
                                             LocalDate repeatEndDate) {
         this.title = title;
         this.detail = detail;
         this.startDate = startDate;
+        this.day = day;
         this.startTime = (startTime != null) ? startTime : LocalTime.of(0, 0);
         this.endTime = (endTime != null) ? endTime : LocalTime.of(23, 59);
         this.repeatFlag = repeatFlag;

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateUpcomingScheduleResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/UpdateUpcomingScheduleResponseDto.java
@@ -1,0 +1,60 @@
+package com.jungle.studybbitback.domain.room.dto.schedule;
+
+import com.jungle.studybbitback.common.utils.DateUtils;
+import com.jungle.studybbitback.domain.room.entity.schedule.Schedule;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class UpdateUpcomingScheduleResponseDto {
+    private Long scheduleId;
+    private String title;
+    private String detail;
+    private LocalDate startDate; // 시작 날짜
+    private String day;
+    private LocalTime startTime;  // 시작 시간
+    private LocalTime endTime;    // 종료 시간
+    private boolean repeatFlag;
+    private String repeatPattern;
+    private String daysOfWeek;
+    private LocalDate repeatEndDate;
+    private Long scheduleCycleId; // 단일일정은 null로 받음 & 반복 일정에서 하루만 수정하면 역시 null로 옴
+
+    // Schedule 엔터티를 기반으로 DTO를 생성하는 생성자
+    public UpdateUpcomingScheduleResponseDto(Schedule schedule) {
+        this.scheduleId = schedule.getId();
+        this.title = schedule.getTitle();
+        this.detail = schedule.getDetail();
+        this.startDate = schedule.getStartDate();
+        this.day = DateUtils.getDayInKorean(schedule.getStartDate().getDayOfWeek());
+        this.startTime = schedule.getStartDateTime().toLocalTime();
+        this.endTime = schedule.getEndDateTime().toLocalTime();
+        this.repeatFlag = schedule.isRepeatFlag();
+        this.repeatPattern = schedule.getRepeatPattern();
+        this.daysOfWeek = schedule.getDaysOfWeek();
+        this.repeatEndDate = schedule.getRepeatEndDate();
+        this.scheduleCycleId = schedule.getScheduleCycleId();
+    }
+
+    // 추가 생성자: 전달받은 파라미터로 DTO 생성
+    public UpdateUpcomingScheduleResponseDto(Long scheduleId, String title, LocalDate startDate,
+                                             LocalTime startTime, LocalTime endTime) {
+        this.scheduleId = scheduleId;
+        this.title = title;
+        this.startDate = startDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        // 기본값 설정 (필요한 필드만 초기화)
+        this.detail = "";  // 기본값으로 빈 문자열 설정
+        this.day = DateUtils.getDayInKorean(startDate.getDayOfWeek());  // 요일 계산
+        this.repeatFlag = false; // 기본값
+        this.repeatPattern = ""; // 기본값
+        this.daysOfWeek = ""; // 기본값
+        this.repeatEndDate = null; // 기본값
+        this.scheduleCycleId = null; // 기본값
+    }
+}

--- a/src/main/java/com/jungle/studybbitback/domain/room/entity/schedule/Schedule.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/entity/schedule/Schedule.java
@@ -37,6 +37,9 @@ public class Schedule extends ModifiedTimeEntity {
     @Column(name = "start_date", nullable = false)
     private LocalDate startDate;  // 일정의 시작날짜(하루 단위 날짜)
 
+    @Column(nullable = false)
+    private String day;  // 요일 컬럼 (예: 월, 화, 수 등)
+
     @Column(name = "start_date_time", nullable = false)
     private LocalDateTime startDateTime;  // 시작 시간
 
@@ -81,6 +84,7 @@ public class Schedule extends ModifiedTimeEntity {
         Schedule schedule = new Schedule();
         schedule.title = requestDto.getTitle();
         schedule.startDate = requestDto.getStartDate();
+        schedule.day = requestDto.getStartDate().getDayOfWeek().getDisplayName(java.time.format.TextStyle.SHORT, java.util.Locale.KOREAN);
         schedule.startDateTime = requestDto.getStartDate().atTime(requestDto.getStartTime());
         schedule.endDateTime = requestDto.getStartDate().atTime(requestDto.getEndTime());
         schedule.detail = requestDto.getDetail();
@@ -98,6 +102,7 @@ public class Schedule extends ModifiedTimeEntity {
         Schedule schedule = new Schedule();
         schedule.title = requestDto.getTitle();
         schedule.startDate = requestDto.getStartDate();
+        schedule.day = requestDto.getStartDate().getDayOfWeek().getDisplayName(java.time.format.TextStyle.SHORT, java.util.Locale.KOREAN);
         schedule.startDateTime = requestDto.getStartDate().atTime(requestDto.getStartTime());
         schedule.endDateTime = requestDto.getStartDate().atTime(requestDto.getEndTime());
         schedule.detail = requestDto.getDetail();
@@ -110,13 +115,14 @@ public class Schedule extends ModifiedTimeEntity {
         return schedule;
     }
 
-    // 일저 세부사항 수정
-    public void updateDetails(String title, String detail, LocalDate startDate, LocalDateTime startTime, LocalDateTime endTime,
+    // 일정 세부사항 수정
+    public void updateDetails(String title, String detail, LocalDate startDate, String day, LocalDateTime startTime, LocalDateTime endTime,
                               Boolean repeatFlag, String repeatPattern, String daysOfWeek, LocalDate repeatEndDate) {
         if(title != null) this.title = title;
         if(detail != null) this.detail = detail;
         if(startDate != null){
             this.startDate = startDate;
+            this.day = startDate.getDayOfWeek().getDisplayName(java.time.format.TextStyle.SHORT, java.util.Locale.KOREAN);
             this.startDateTime = startTime;
             // endDateTime이 null이면 기본값을 설정하거나 예외를 던질 수 있습니다
             if (endTime != null) {
@@ -130,8 +136,11 @@ public class Schedule extends ModifiedTimeEntity {
             this.repeatFlag = repeatFlag;
             this.repeatPattern = repeatPattern;
             this.daysOfWeek = daysOfWeek;
-            if (repeatFlag) { // 반복 일정일 경우에만 repeatEndDate를 설정
+            // 반복 일정일 경우에만 repeatEndDate를 설정, 그렇지 않으면 null로 설정
+            if (repeatFlag) {
                 this.repeatEndDate = repeatEndDate;
+            } else {
+                this.repeatEndDate = null; // 단일 일정이므로 반복 종료일은 null
             }
         }
     }

--- a/src/main/java/com/jungle/studybbitback/domain/room/entity/schedule/Schedule.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/entity/schedule/Schedule.java
@@ -3,6 +3,7 @@ package com.jungle.studybbitback.domain.room.entity.schedule;
 import com.jungle.studybbitback.common.entity.ModifiedTimeEntity;
 import com.jungle.studybbitback.domain.member.entity.Member;
 import com.jungle.studybbitback.domain.room.dto.schedule.CreateScheduleRequestDto;
+import com.jungle.studybbitback.domain.room.dto.schedule.UpdateUpcomingScheduleRequestDto;
 import com.jungle.studybbitback.domain.room.entity.Room;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -92,6 +93,24 @@ public class Schedule extends ModifiedTimeEntity {
         return schedule;
     }
 
+    // 새로운: UpdateUpcomingScheduleRequestDto를 사용하여 일정 수정
+    public static Schedule from(UpdateUpcomingScheduleRequestDto requestDto, Room room, Member createdBy) {
+        Schedule schedule = new Schedule();
+        schedule.title = requestDto.getTitle();
+        schedule.startDate = requestDto.getStartDate();
+        schedule.startDateTime = requestDto.getStartDate().atTime(requestDto.getStartTime());
+        schedule.endDateTime = requestDto.getStartDate().atTime(requestDto.getEndTime());
+        schedule.detail = requestDto.getDetail();
+        schedule.room = room;
+        schedule.createdBy = createdBy;
+        schedule.repeatFlag = requestDto.isRepeatFlag();
+        schedule.repeatPattern = requestDto.getRepeatPattern();
+        schedule.daysOfWeek = requestDto.getDaysOfWeek();
+        schedule.repeatEndDate = requestDto.getRepeatEndDate();
+        return schedule;
+    }
+
+    // 일저 세부사항 수정
     public void updateDetails(String title, String detail, LocalDate startDate, LocalDateTime startTime, LocalDateTime endTime,
                               Boolean repeatFlag, String repeatPattern, String daysOfWeek, LocalDate repeatEndDate) {
         if(title != null) this.title = title;
@@ -111,8 +130,12 @@ public class Schedule extends ModifiedTimeEntity {
             this.repeatFlag = repeatFlag;
             this.repeatPattern = repeatPattern;
             this.daysOfWeek = daysOfWeek;
-            this.repeatEndDate = repeatEndDate;
+            if (repeatFlag) { // 반복 일정일 경우에만 repeatEndDate를 설정
+                this.repeatEndDate = repeatEndDate;
+            }
         }
     }
+
+
 
 }

--- a/src/main/java/com/jungle/studybbitback/domain/room/respository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/respository/schedule/ScheduleRepository.java
@@ -5,8 +5,10 @@ import com.jungle.studybbitback.domain.room.entity.schedule.Schedule;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
@@ -30,4 +32,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     void deleteByScheduleCycleId(Long scheduleCycleId);
 
+    @Query("SELECT COALESCE(MAX(s.scheduleCycleId), 0) FROM Schedule s")
+    Optional<Long> findMaxScheduleCycleId();
 }
+

--- a/src/main/java/com/jungle/studybbitback/domain/room/service/schedule/ScheduleService.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/service/schedule/ScheduleService.java
@@ -177,6 +177,7 @@ public class ScheduleService {
                         CreateScheduleRequestDto.builder()
                                 .title(requestDto.getTitle())
                                 .startDate(currentDate)
+                                .day(requestDto.getDay())
                                 .startTime(currentStartDateTime.toLocalTime())
                                 .endTime(currentEndDateTime.toLocalTime())
                                 .detail(requestDto.getDetail())
@@ -278,6 +279,7 @@ public class ScheduleService {
                 updateScheduleRequestDto.getTitle(),
                 updateScheduleRequestDto.getDetail(),
                 updateScheduleRequestDto.getStartDate(),
+                updateScheduleRequestDto.getDay(),
                 updateScheduleRequestDto.getStartDateTime(),
                 updateScheduleRequestDto.getEndDateTime(),
                 updateScheduleRequestDto.isRepeatFlag(),
@@ -325,9 +327,11 @@ public class ScheduleService {
             if (newDaysOfWeek.contains(current.getDayOfWeek())) {
                 LocalDateTime startDateTime = current.atTime(requestDto.getStartTime());
                 LocalDateTime endDateTime = current.atTime(requestDto.getEndTime());
+
                 Schedule newSchedule = Schedule.builder()
                         .title(requestDto.getTitle())
                         .detail(requestDto.getDetail())
+                        .day(requestDto.getDay())
                         .startDate(current)
                         .startDateTime(startDateTime)
                         .endDateTime(endDateTime)
@@ -411,6 +415,7 @@ public class ScheduleService {
                         .title(requestDto.getTitle())
                         .detail(requestDto.getDetail())
                         .startDate(currentDate)
+                        .day(requestDto.getDay())
                         .startTime(requestDto.getStartTime())
                         .endTime(requestDto.getEndTime())
                         .roomId(room.getId())


### PR DESCRIPTION
🚩현재 일정 수정 메서드 중 
하루 수정(single), 특정날짜 이후 전체 반복일정 수정(upcoming)은 가능하지만
모든 일정 수정(All)은 요일 컬럼인 day 값이 저장되지 않고 있습니다.

+) Entity에는 시작, 종료시간 타입이 localDateTime이라서 startDateTime, endDateTime으로 정의되어있습니다. 
그러나 dto에서는 입력 시 편의를 위해 타입을 localTime으로만 사용하여 startTime, endTime으로 넘기고 있습니다.
startDate(당일날짜)에 귀속시키기 위해 필드타입을 그대로 유지했는데요, 필요시 수정하겠습니다.

String title; 일정 제목

LocalDate startDate  : 일정의 날짜(반복일정의 기준 날짜)

String day : 요일 정보

LocalDateTime startDateTime  : 일정 하루에 대한 시작시간

LocalDateTime endDateTime  : 일정 하루에 대한 종료시간

String detail : 일정 설명

boolean repeatFlag : 일정 반복 사용 여부
String repeatPattern : 반복 패턴 (주간)
String daysOfWeek : 반복 요일
LocalDate repeatEndDate : 반복 일정 종료 날짜

Long scheduleCycleId : 반복일정일 경우 그룹핑 용도 