### PR TITLE
chore. 일정, 게시글, 게시글댓글에서 memberId 받아오게 추가

### DIFF
--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/GetRoomBoardDetailResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/GetRoomBoardDetailResponseDto.java
@@ -22,7 +22,8 @@ public class GetRoomBoardDetailResponseDto {
     private Long roomBoardId;
     private String title;
     private String content;
-    private String createdBy; // 게시글 작성자 닉네임
+    private Long memberId;
+    private String createdByNickname; // 게시글 작성자 닉네임
     private String createdByProfileUrl; // 게시글 작성자 프로필 이미지 URL
     private boolean isNotice;
     private Long roomId;
@@ -40,6 +41,7 @@ public class GetRoomBoardDetailResponseDto {
             return new GetRoomBoardCommentResponseDto(
                     comment.getId(),
                     comment.getContent(),
+                    commentCreator.getId(),
                     commentCreator.getNickname(),
                     commentCreator.getProfileImageUrl(), // 프로필 이미지 URL을 포함
                     comment.getCreatedAt(),
@@ -51,6 +53,7 @@ public class GetRoomBoardDetailResponseDto {
                 roomBoard.getId(),
                 roomBoard.getTitle(),
                 roomBoard.getContent(),
+                roomBoardCreator.getId(),
                 roomBoardCreator.getNickname(), // 게시글 작성자 닉네임
                 roomBoardCreator.getProfileImageUrl(), // 게시글 작성자 프로필 이미지 URL
                 roomBoard.isNotice(),

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/GetRoomBoardResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboard/GetRoomBoardResponseDto.java
@@ -15,7 +15,8 @@ public class GetRoomBoardResponseDto {
     private Long roomBoardId;
     private String title;
     private String content;
-    private String createdBy;
+    private Long memberId;
+    private String createdByNickname;
     private String createdByProfileUrl;
     private LocalDateTime createdAt;
     private boolean isNotice;
@@ -27,6 +28,7 @@ public class GetRoomBoardResponseDto {
                 roomBoard.getId(),
                 roomBoard.getTitle(),
                 roomBoard.getContent(),
+                roomBoard.getCreatedBy(), //memberId
                 member.getNickname(), // 닉네임을 외부에서 전달
                 member.getProfileImageUrl(),
                 roomBoard.getCreatedAt(),

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/GetRoomBoardCommentResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/roomboardcomment/GetRoomBoardCommentResponseDto.java
@@ -10,16 +10,18 @@ import java.time.LocalDateTime;
 public class GetRoomBoardCommentResponseDto {
     private Long id;
     private String content;
-    private String createdBy;
-    private LocalDateTime createdAt;
+    private Long memberId;
+    private String createdByNickname;
     private String createdByProfileUrl;
+    private LocalDateTime createdAt;
     private Long roomBoardId;
 
     //
-    public GetRoomBoardCommentResponseDto(Long id, String content, String createdBy, String createdByProfileUrl, LocalDateTime createdAt, Long roomBoardId) {
+    public GetRoomBoardCommentResponseDto(Long id, String content, Long memberId, String createdByNickname, String createdByProfileUrl, LocalDateTime createdAt, Long roomBoardId) {
         this.id = id;
         this.content = content;
-        this.createdBy = createdBy;
+        this.memberId = memberId;
+        this.createdByNickname = createdByNickname;
         this.createdByProfileUrl = createdByProfileUrl; // 생성자에서 프로필 이미지 URL 초기화
         this.createdAt = createdAt;
         this.roomBoardId = roomBoardId;

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/GetScheduleDetailResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/GetScheduleDetailResponseDto.java
@@ -21,7 +21,8 @@ public class GetScheduleDetailResponseDto {
     private LocalTime endTime;    // 종료 시간
     private String detail;
     private Long roomId;
-    private String creatorName;
+    private Long memberId;
+    private String createdByNickname;
     private boolean repeatFlag; // 반복 여부
     private String repeatPattern; // 반복 패턴
     private String daysOfWeek; // 반복 요일
@@ -41,7 +42,8 @@ public class GetScheduleDetailResponseDto {
                 .endTime(schedule.getEndDateTime().toLocalTime())
                 .detail(schedule.getDetail())
                 .roomId(schedule.getRoom().getId())
-                .creatorName(schedule.getCreatedBy().getNickname())
+                .memberId(schedule.getCreatedBy().getId())
+                .createdByNickname(schedule.getCreatedBy().getNickname())
                 .repeatFlag(schedule.isRepeatFlag())
                 .repeatPattern(schedule.getRepeatPattern())
                 .daysOfWeek(schedule.getDaysOfWeek())

--- a/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/GetScheduleResponseDto.java
+++ b/src/main/java/com/jungle/studybbitback/domain/room/dto/schedule/GetScheduleResponseDto.java
@@ -19,7 +19,8 @@ public class GetScheduleResponseDto {
     private LocalTime endTime;    // 종료 시간
     private String detail;
     private Long roomId;
-    private String creatorName;
+    private Long memberId;
+    private String createdByNickname;
     private boolean repeatFlag; // 반복 여부
     private String repeatPattern; // 반복 패턴
     private String daysOfWeek; // 반복 요일
@@ -36,7 +37,8 @@ public class GetScheduleResponseDto {
                 .endTime(schedule.getEndDateTime().toLocalTime())
                 .detail(schedule.getDetail())
                 .roomId(schedule.getRoom().getId())
-                .creatorName(schedule.getCreatedBy().getNickname())
+                .memberId(schedule.getCreatedBy().getId())
+                .createdByNickname(schedule.getCreatedBy().getNickname())
                 .repeatFlag(schedule.isRepeatFlag())
                 .repeatPattern(schedule.getRepeatPattern())
                 .daysOfWeek(schedule.getDaysOfWeek())


### PR DESCRIPTION
memberId 받아오게 추가 : 똑같이 memberId 로 불러오면 됩니다.

nickname은 기존 필드명이 조금씩 달라서 변경사항 아래로 적습니다. 
createdByNickname으로 불러오시면 됩니다.

게시글 조회, 상세조회, 댓글조회: createdBy -> " createdByNickname"
일정에서 creatorname -> "createdByNickname"